### PR TITLE
Apply 3-model adversarial review findings

### DIFF
--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -204,8 +204,9 @@ Examples:
     help=(
         "If specified, audio and subtitle tracks whose name contains 'commentary'"
         " (case-insensitive) will be removed after language filtering."
-        " Safety fallbacks apply: if stripping would leave no audio tracks, all audio is kept"
-        " and a warning is logged; same for subtitles."
+        " Audio safety fallback: if stripping commentary would leave no audio tracks, all audio is kept"
+        " and a warning is logged. Subtitle commentary tracks are stripped unconditionally"
+        " (a subtitle-free file is acceptable)."
         " Has no effect on audio when --keep-audio is set, or on subtitles when --keep-subtitles is set."
         " Disabled by default."
     ),

--- a/src/core/processor.py
+++ b/src/core/processor.py
@@ -95,7 +95,7 @@ _ISO_639_1_TO_2: dict[str, str] = {
     "ms": "may",
     "ml": "mal",
     "mt": "mlt",
-    "nb": "nor",
+    "nb": "nob",
     "fa": "per",
     "pl": "pol",
     "pt": "por",
@@ -291,7 +291,7 @@ def build_mkvmerge_command(
     keep_subtitles: bool,
     edit_metadata_title: bool,
     delete_metadata_title: bool,
-    logger: Logger | None = None,
+    logger: Logger,
     strip_lower_channels: bool = False,
     strip_commentary: bool = False,
 ) -> list[str] | None:
@@ -373,14 +373,13 @@ def build_mkvmerge_command(
     # Channel-strip is also skipped when a fallback fires — when we're already
     # in a "best effort, keep everything" state there is no benefit in pruning
     # further by channel count.
+    lang_desc = f"'{language[0]}'" if len(language) == 1 else str(language)
     audio_fallback_fired = False
     if audio_drop and not audio_keep:
-        if logger is not None:
-            lang_desc = f"'{language[0]}'" if len(language) == 1 else str(language)
-            logger.warning(
-                f"No audio tracks match language {lang_desc} in '{input_path.name}' "
-                f"— keeping all audio to prevent silent data loss."
-            )
+        logger.warning(
+            f"No audio tracks match language {lang_desc} in '{input_path.name}' "
+            f"— keeping all audio to prevent silent data loss."
+        )
         audio_drop.clear()
         audio_fallback_fired = True
     elif audio_drop:
@@ -390,23 +389,17 @@ def build_mkvmerge_command(
         # preferred-language audio is the commentary track, not the main dub).
         audio_commentary_ids = {t.id for t in tracks if t.type == "audio" and _is_commentary(t.name)}
         if all(tid in audio_commentary_ids for tid in audio_keep):
-            if logger is not None:
-                lang_desc = f"'{language[0]}'" if len(language) == 1 else str(language)
-                logger.warning(
-                    f"All audio tracks matching language {lang_desc} in '{input_path.name}' are commentary "
-                    f"— keeping all audio to avoid commentary-only audio."
-                )
+            logger.warning(
+                f"All audio tracks matching language {lang_desc} in '{input_path.name}' are commentary "
+                f"— keeping all audio to avoid commentary-only audio."
+            )
             audio_drop.clear()
             audio_fallback_fired = True
 
     # Same safety fallback for subtitles.
     sub_fallback_fired = False
     if sub_drop and not sub_keep:
-        if logger is not None:
-            lang_desc = f"'{language[0]}'" if len(language) == 1 else str(language)
-            logger.warning(
-                f"No subtitle tracks match language {lang_desc} in '{input_path.name}' — keeping all subtitles."
-            )
+        logger.warning(f"No subtitle tracks match language {lang_desc} in '{input_path.name}' — keeping all subtitles.")
         sub_drop.clear()
         sub_fallback_fired = True
 
@@ -437,11 +430,10 @@ def build_mkvmerge_command(
                 remaining = [i for i in audio_keep if i not in set(audio_commentary_to_drop)]
                 if not remaining:
                     # Final gate: stripping would leave zero audio — keep all and warn.
-                    if logger is not None:
-                        logger.warning(
-                            f"All audio tracks in '{input_path.name}' are commentary "
-                            f"— keeping all audio to prevent silent output."
-                        )
+                    logger.warning(
+                        f"All audio tracks in '{input_path.name}' are commentary "
+                        f"— keeping all audio to prevent silent output."
+                    )
                 else:
                     commentary_audio_drop_ids = set(audio_commentary_to_drop)
                     for tid in audio_commentary_to_drop:
@@ -493,12 +485,11 @@ def build_mkvmerge_command(
             for tid in channel_drop:
                 audio_keep.remove(tid)
                 audio_drop.append(tid)
-            if logger is not None:
-                descs = ", ".join(_fmt_track(t) for t in surviving if t.id in channel_drop_set)
-                logger.info(
-                    f"  Dropping {len(channel_drop)} audio track(s) with fewer channels than the per-language maximum."
-                )
-                logger.debug(f"  Dropping lower-channel audio track(s): {descs}")
+            descs = ", ".join(_fmt_track(t) for t in surviving if t.id in channel_drop_set)
+            logger.info(
+                f"  Dropping {len(channel_drop)} audio track(s) with fewer channels than the per-language maximum."
+            )
+            logger.debug(f"  Dropping lower-channel audio track(s): {descs}")
 
     needs_audio_change = bool(audio_drop)
     needs_sub_change = bool(sub_drop)
@@ -508,30 +499,27 @@ def build_mkvmerge_command(
         return None
 
     # Log what is being changed and why, so the user has full visibility.
-    if logger is not None:
-        lang_filter = f"≠ '{language[0]}'" if len(language) == 1 else f"not in {language}"
-        if language_audio_drop_ids:
-            logger.info(f"  Dropping {len(language_audio_drop_ids)} audio track(s) (language {lang_filter}).")
-            descs = ", ".join(_fmt_track(t) for t in tracks if t.type == "audio" and t.id in language_audio_drop_ids)
-            logger.debug(f"  Dropping audio track(s): {descs}")
-        if language_sub_drop_ids and needs_sub_change:
-            logger.info(f"  Dropping {len(language_sub_drop_ids)} subtitle track(s) (language {lang_filter}).")
-            descs = ", ".join(_fmt_track(t) for t in tracks if t.type == "subtitles" and t.id in language_sub_drop_ids)
-            logger.debug(f"  Dropping subtitle track(s): {descs}")
-        if commentary_audio_drop_ids:
-            logger.info(f"  Dropping {len(commentary_audio_drop_ids)} audio commentary track(s).")
-            descs = ", ".join(_fmt_track(t) for t in tracks if t.type == "audio" and t.id in commentary_audio_drop_ids)
-            logger.debug(f"  Dropping audio commentary track(s): {descs}")
-        if commentary_sub_drop_ids:
-            logger.info(f"  Dropping {len(commentary_sub_drop_ids)} subtitle commentary track(s).")
-            descs = ", ".join(
-                _fmt_track(t) for t in tracks if t.type == "subtitles" and t.id in commentary_sub_drop_ids
-            )
-            logger.debug(f"  Dropping subtitle commentary track(s): {descs}")
-        if edit_metadata_title:
-            logger.info(f"  Metadata: setting title to '{input_path.stem}'")
-        elif delete_metadata_title:
-            logger.info("  Metadata: clearing title")
+    lang_filter = f"≠ '{language[0]}'" if len(language) == 1 else f"not in {language}"
+    if language_audio_drop_ids and needs_audio_change:
+        logger.info(f"  Dropping {len(language_audio_drop_ids)} audio track(s) (language {lang_filter}).")
+        descs = ", ".join(_fmt_track(t) for t in tracks if t.type == "audio" and t.id in language_audio_drop_ids)
+        logger.debug(f"  Dropping audio track(s): {descs}")
+    if language_sub_drop_ids and needs_sub_change:
+        logger.info(f"  Dropping {len(language_sub_drop_ids)} subtitle track(s) (language {lang_filter}).")
+        descs = ", ".join(_fmt_track(t) for t in tracks if t.type == "subtitles" and t.id in language_sub_drop_ids)
+        logger.debug(f"  Dropping subtitle track(s): {descs}")
+    if commentary_audio_drop_ids:
+        logger.info(f"  Dropping {len(commentary_audio_drop_ids)} audio commentary track(s).")
+        descs = ", ".join(_fmt_track(t) for t in tracks if t.type == "audio" and t.id in commentary_audio_drop_ids)
+        logger.debug(f"  Dropping audio commentary track(s): {descs}")
+    if commentary_sub_drop_ids:
+        logger.info(f"  Dropping {len(commentary_sub_drop_ids)} subtitle commentary track(s).")
+        descs = ", ".join(_fmt_track(t) for t in tracks if t.type == "subtitles" and t.id in commentary_sub_drop_ids)
+        logger.debug(f"  Dropping subtitle commentary track(s): {descs}")
+    if edit_metadata_title:
+        logger.info(f"  Metadata: setting title to '{input_path.stem}'")
+    elif delete_metadata_title:
+        logger.info("  Metadata: clearing title")
 
     cmd: list[str] = [mkvmerge_path, "-o", str(output_path)]
 
@@ -587,11 +575,10 @@ def build_mkvmerge_command(
             for t in commentary_kept:
                 if t.default_track:
                     default_flags += ["--default-track", f"{t.id}:0"]
-            if logger is not None:
-                logger.warning(
-                    f"All remaining {track_type} tracks in '{input_path.name}' are commentary "
-                    f"— cannot reassign default {track_type} track."
-                )
+            logger.warning(
+                f"All remaining {track_type} tracks in '{input_path.name}' are commentary "
+                f"— cannot reassign default {track_type} track."
+            )
 
     cmd += default_flags
     cmd.append(str(input_path))
@@ -722,8 +709,8 @@ def process_file(
                     try:
                         backup_path.replace(file_path)
                     except Exception as restore_exc:
-                        logger.error(
-                            f"CRITICAL: Could not restore original from backup '{backup_path}': {restore_exc}. "
+                        logger.critical(
+                            f"Could not restore original from backup '{backup_path}': {restore_exc}. "
                             f"Original is at '{backup_path}'."
                         )
                 raise
@@ -734,6 +721,7 @@ def process_file(
 
     except Exception as exc:  # noqa: BLE001
         logger.error(f"Unexpected error processing '{file_path}': {exc}")
+        logger.debug("", exc_info=True)
         return False
     finally:
         if tmp_path is not None and tmp_path.exists():

--- a/src/trimarr/main.py
+++ b/src/trimarr/main.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import json
 import shutil
@@ -49,7 +50,7 @@ def _build_profile_hash(
     Run-time options (``dry_run``, ``no_backup``, paths) are deliberately excluded.
 
     Args:
-        language: Sorted list of ISO 639-2 language codes to retain.
+        language: List of ISO 639-2 language codes to retain (sorted internally).
         keep_audio: Retain all audio tracks regardless of language.
         keep_subtitles: Retain all subtitle tracks regardless of language.
         edit_metadata_title: Set container title to filename stem.
@@ -174,7 +175,7 @@ def run(
         logger.error(f"Media path '{media_path}' is not a directory.")
         return
 
-    mkv_files = sorted(root.rglob("*.mkv"))
+    mkv_files = sorted(p for p in root.rglob("*") if p.suffix.lower() == ".mkv")
 
     if not mkv_files:
         logger.warning(f"No .mkv files found under '{media_path}'.")
@@ -252,7 +253,8 @@ def run(
                         # execution strategy; mkvmerge refuses input == output, so showing the raw
                         # command (where placeholder output_path == input_path) would be misleading.
                         display_cmd = list(cmd)
-                        display_cmd[display_cmd.index("-o") + 1] = "[tmpfile]"
+                        with contextlib.suppress(ValueError):
+                            display_cmd[display_cmd.index("-o") + 1] = "[tmpfile]"
                         # Escape angle brackets in dynamic content (file paths, titles) so loguru's
                         # colour parser does not mistake them for markup tags.
                         cmd_str = " ".join(display_cmd).replace("<", r"\<").replace(">", r"\>")

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import os
 import platform
 import stat
@@ -91,10 +92,10 @@ def _extract_from_tar(archive_path: Path, binary_name: str, tmp_dir: Path) -> Pa
         if member is None:
             raise RuntimeError(f"Could not find '{binary_name}' inside '{archive_path.name}'.")
         tar.extract(member, path=tmp_dir, filter="data")
-    matches = list(tmp_dir.rglob(binary_name))
-    if not matches:
+    extracted = tmp_dir / member.name
+    if not extracted.exists():
         raise RuntimeError(f"Could not locate '{binary_name}' after extraction.")
-    return matches[0]
+    return extracted
 
 
 def _extract_from_zip(archive_path: Path, binary_name: str, tmp_dir: Path) -> Path:
@@ -103,11 +104,14 @@ def _extract_from_zip(archive_path: Path, binary_name: str, tmp_dir: Path) -> Pa
         names = [n for n in zf.namelist() if Path(n).name == binary_name]
         if not names:
             raise RuntimeError(f"Could not find '{binary_name}' inside '{archive_path.name}'.")
+        # Validate the entry does not escape the extraction directory (path-traversal guard).
+        extracted = (tmp_dir / names[0]).resolve()
+        if not str(extracted).startswith(str(tmp_dir.resolve())):
+            raise RuntimeError(f"Archive entry '{names[0]}' would escape the extraction directory.")
         zf.extract(names[0], path=tmp_dir)
-    matches = list(tmp_dir.rglob(binary_name))
-    if not matches:
+    if not extracted.exists():
         raise RuntimeError(f"Could not locate '{binary_name}' after extraction.")
-    return matches[0]
+    return extracted
 
 
 def _fetch_latest_release(repo: str) -> dict:
@@ -275,7 +279,8 @@ def download_mkvmerge(dest_dir: str | Path | None = None) -> Path:
                 tmp_bin.chmod(tmp_bin.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
             os.replace(tmp_bin, dest_binary)
         except Exception:
-            tmp_bin.unlink(missing_ok=True)
+            with contextlib.suppress(OSError):
+                tmp_bin.unlink(missing_ok=True)
             raise
 
     # Atomically write the version file so the binary and version are never mismatched.
@@ -287,7 +292,8 @@ def download_mkvmerge(dest_dir: str | Path | None = None) -> Path:
         tmp_ver.write_text(release_tag, encoding="utf-8")
         os.replace(tmp_ver, dest_dir / _VERSION_FILE)
     except Exception:
-        tmp_ver.unlink(missing_ok=True)
+        with contextlib.suppress(OSError):
+            tmp_ver.unlink(missing_ok=True)
         raise
 
     return dest_binary

--- a/tests/unit/test_processor.py
+++ b/tests/unit/test_processor.py
@@ -74,7 +74,7 @@ def _build_cmd(
         keep_subtitles=keep_subtitles,
         edit_metadata_title=edit_metadata_title,
         delete_metadata_title=delete_metadata_title,
-        logger=logger,
+        logger=logger or MagicMock(),
         strip_lower_channels=strip_lower_channels,
         strip_commentary=strip_commentary,
     )
@@ -620,19 +620,18 @@ class TestCommentaryDefaultTrack:
         assert result is None
 
     def test_commentary_name_case_insensitive(self) -> None:
-        """Commentary matching is case-insensitive (e.g. 'COMMENTARY', 'Commentary 2')."""
-        for name in ("COMMENTARY", "commentary", "Director's Commentary", "Commentary 2"):
-            tracks = [
-                MkvTrack(id=0, type="video", language=None),
-                MkvTrack(id=1, type="audio", language="eng", name=name, default_track=True),
-                MkvTrack(id=2, type="audio", language="eng", name="Main", default_track=False),
-                MkvTrack(id=3, type="audio", language="fre"),
-            ]
-            cmd = _build_cmd(tracks)
-            assert cmd is not None, f"Expected command for name={name!r}"
-            assert "--default-track" in cmd, f"Expected flags for name={name!r}"
-            assert "1:0" in cmd
-            assert "2:1" in cmd
+        """Commentary matching is case-insensitive; default-track reassignment applies."""
+        tracks = [
+            MkvTrack(id=0, type="video", language=None),
+            MkvTrack(id=1, type="audio", language="eng", name="Director's Commentary", default_track=True),
+            MkvTrack(id=2, type="audio", language="eng", name="Main", default_track=False),
+            MkvTrack(id=3, type="audio", language="fre"),
+        ]
+        cmd = _build_cmd(tracks)
+        assert cmd is not None
+        assert "--default-track" in cmd
+        assert "1:0" in cmd
+        assert "2:1" in cmd
 
 
 # ---------------------------------------------------------------------------
@@ -736,21 +735,6 @@ class TestProcessFile:
         logger.error.assert_called_once()
         assert not list(tmp_path.glob("*.trimarr_tmp"))  # No leftover temp files
 
-    def test_empty_output_treated_as_failure(self, tmp_path: Path) -> None:
-        mkv = tmp_path / "movie.mkv"
-        mkv.write_bytes(b"original")
-        cmd = _proc_cmd(mkv, tmp_path / "out.mkv")
-
-        def fake_run(args: list[str], **kwargs: object) -> MagicMock:
-            Path(args[2]).write_bytes(b"")  # Empty file
-            return MagicMock(returncode=0, stdout="", stderr="")
-
-        with patch("subprocess.run", side_effect=fake_run):
-            result = process_file(MKVMERGE, mkv, cmd, no_backup=False, logger=_proc_logger())
-
-        assert result is False
-        assert mkv.read_bytes() == b"original"
-
     def test_no_backup_uses_atomic_replace_not_delete_first(self, tmp_path: Path) -> None:
         """Verify no-backup mode does NOT delete the original before renaming.
 
@@ -841,8 +825,9 @@ class TestProcessFile:
             result = process_file(MKVMERGE, mkv, cmd, no_backup=False, logger=logger)
 
         assert result is False
-        error_calls = " ".join(str(c) for c in logger.error.call_args_list)
-        assert "CRITICAL" in error_calls
+        assert logger.critical.call_count >= 1
+        critical_calls = " ".join(str(c) for c in logger.critical.call_args_list)
+        assert "backup" in critical_calls.lower()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
- Fix 'nb' ISO 639-2 mapping: 'nor' (generic) → 'nob' (Bokmål)
- Make logger required in build_mkvmerge_command(); remove 6x 'if logger is not None' guards
- Extract lang_desc calculation to a single variable before fallback blocks (was duplicated verbatim 3 times)
- Gate language-audio drop log with needs_audio_change to prevent false 'Dropping N audio track(s)' messages when fallback kept all
- Replace logger.error + 'CRITICAL:' prefix with logger.critical for the backup-rollback data-loss scenario
- Add logger.debug(exc_info=True) to broad except handler so tracebacks surface at --verbose level
- Fix rglob nondeterminism in archive extraction: use exact extracted member path instead of searching via rglob (tar + zip)
- Add path-traversal guard to _extract_from_zip before extraction
- Wrap temp-file cleanup in contextlib.suppress(OSError) so cleanup failures never replace the original exception
- Case-insensitive MKV scan: rglob('*.mkv') → suffix.lower() == '.mkv'
- Safe -o index lookup in dry-run display path using contextlib.suppress
- Fix --strip-commentary help text: correctly describes audio-only safety gate (subtitle strip is unconditional)
- Fix _build_profile_hash docstring: language is sorted internally
- Remove duplicate test_empty_output_treated_as_failure (covered by TestTruncatedOutputRejection suite)
- Simplify test_commentary_name_case_insensitive to a single case variant (case-sensitivity exhaustively tested by TestStripCommentary)
- Update test_backup_mode_logs_critical_when_rollback_also_fails to assert logger.critical rather than 'CRITICAL' in error messages
- _build_cmd test helper: pass logger or MagicMock() so it always provides a real logger to build_mkvmerge_command