### PR TITLE
fix: metadata title flags no-op when container title already matches (issue #72)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "Trimarr"
-version = "1.2.11"
+version = "1.2.12"
 description = "Automated tool"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/trimarr/processor.py
+++ b/src/trimarr/processor.py
@@ -14,7 +14,7 @@ import threading
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -336,10 +336,11 @@ def _parse_track(raw: dict) -> MkvTrack:
     )
 
 
-def probe_file(mkvmerge_path: str, file_path: Path) -> list[MkvTrack]:
-    """Run ``mkvmerge -J`` on *file_path* and return the list of :class:`MkvTrack` objects.
+def _run_mkvmerge_probe(mkvmerge_path: str, file_path: Path) -> dict:
+    """Run ``mkvmerge -J`` and return the parsed JSON dict.
 
     Raises :exc:`RuntimeError` on non-zero exit, timeout, OS error, or JSON parse failure.
+    Shared helper used by :func:`probe_file` and :func:`probe_container_title`.
     """
     try:
         result = subprocess.run(
@@ -356,11 +357,40 @@ def probe_file(mkvmerge_path: str, file_path: Path) -> list[MkvTrack]:
     if result.returncode != 0:
         raise RuntimeError(f"mkvmerge -J failed for '{file_path}' (exit {result.returncode}): {result.stderr.strip()}")
     try:
-        info = json.loads(result.stdout)
+        return cast("dict", json.loads(result.stdout))
     except json.JSONDecodeError as exc:
         raise RuntimeError(f"Could not parse mkvmerge JSON output for '{file_path}': {exc}") from exc
 
+
+def probe_file(mkvmerge_path: str, file_path: Path) -> list[MkvTrack]:
+    """Run ``mkvmerge -J`` on *file_path* and return the list of :class:`MkvTrack` objects.
+
+    Raises :exc:`RuntimeError` on non-zero exit, timeout, OS error, or JSON parse failure.
+    """
+    info = _run_mkvmerge_probe(mkvmerge_path, file_path)
     return [_parse_track(raw) for raw in info.get("tracks", [])]
+
+
+def probe_container_title(mkvmerge_path: str, file_path: Path) -> str:
+    """Run ``mkvmerge -J`` on *file_path* and return the container-level title.
+
+    Returns the value of ``container.properties.title`` from the mkvmerge JSON
+    output, or an empty string when the title is absent or missing.
+
+    Raises :exc:`RuntimeError` on non-zero exit, timeout, OS error, or JSON
+    parse failure (same semantics as :func:`probe_file`).
+
+    Note: each call spawns a separate ``mkvmerge -J`` process.  When a caller
+    already has the raw JSON from :func:`probe_file`, the title is available at
+    ``info["container"]["properties"]["title"]`` in that same response.
+    """
+    info = _run_mkvmerge_probe(mkvmerge_path, file_path)
+    # Defensive: handle "container": null (unlikely in practice but would
+    # crash with AttributeError if it occurs).
+    container = info.get("container")
+    if container is None:
+        return ""
+    return container.get("properties", {}).get("title", "") or ""
 
 
 # ---------------------------------------------------------------------------
@@ -748,10 +778,13 @@ def _log_commentary_drops(
 def _log_metadata_title_change(
     edit_metadata_title: bool,
     delete_metadata_title: bool,
+    needs_metadata_change: bool,
     input_path: Path,
     logger: Logger,
 ) -> None:
     """Log the metadata title operation that will be applied."""
+    if not needs_metadata_change:
+        return
     if edit_metadata_title:
         logger.info(f"  Metadata: setting title to '{input_path.stem}'")
     elif delete_metadata_title:
@@ -768,6 +801,7 @@ def _log_filter_changes(
     logger: Logger,
     needs_audio_change: bool,
     needs_sub_change: bool,
+    needs_metadata_change: bool = False,
 ) -> None:
     """Log a human-readable summary of the track changes that will be applied."""
     _log_language_drops(result.language_audio_drop_ids, _TRACK_AUDIO, tracks, language, needs_audio_change, logger)
@@ -780,7 +814,14 @@ def _log_filter_changes(
             _fmt_track(t) for t in tracks if t.type == _TRACK_SUBTITLES and t.id in result.subtitle_regex_drop_ids
         )
         logger.debug(f"  Dropping subtitle track(s) by name regex: {descs}")
-    _log_metadata_title_change(edit_metadata_title, delete_metadata_title, input_path, logger)
+    # Log metadata title change only when it is actually needed (issue #72).
+    _log_metadata_title_change(
+        edit_metadata_title,
+        delete_metadata_title,
+        needs_metadata_change,
+        input_path,
+        logger,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -912,12 +953,20 @@ def build_mkvmerge_command(
     strip_commentary: bool = False,
     strip_subtitle_regex_patterns: list[re.Pattern] | None = None,
     keep_undefined_audio: bool = False,
+    current_title: str = "",
 ) -> list[str] | None:
     """Build the mkvmerge argv for *input_path*; return *None* if no changes are needed.
 
     Runs all filtering phases (language, fallbacks, commentary, regex, channel), then assembles
     the final command.  Returns *None* when no track or metadata changes are required
     so callers can skip mkvmerge and mark the file as already processed.
+
+    *current_title* is the container-level title from ``mkvmerge -J``
+    ``container.properties.title``.  When it already matches the requested metadata
+    operation no remux is performed.  Defaults to ``""`` (empty).  With this default
+    ``edit_metadata_title`` always requests a change (empty never matches a real stem),
+    while ``delete_metadata_title`` sees the title as already empty and skips the remux.
+    Callers that probe the actual container title should pass the real value.
     """
     result = _apply_language_filter(tracks, language, keep_audio, keep_subtitles, keep_undefined_audio)
     _apply_audio_fallbacks(result, tracks, language, logger, input_path)
@@ -928,7 +977,15 @@ def build_mkvmerge_command(
 
     needs_audio_change = bool(result.audio_drop)
     needs_sub_change = bool(result.sub_drop)
-    needs_metadata_change = edit_metadata_title or delete_metadata_title
+    # Determine whether the requested metadata operation would actually change the file.
+    # Issue #72: avoid redundant remux when the container title is already in the
+    # desired state (e.g. after DB loss or config reset).
+    if edit_metadata_title:
+        needs_metadata_change = current_title != input_path.stem
+    elif delete_metadata_title:
+        needs_metadata_change = bool(current_title)
+    else:
+        needs_metadata_change = False
 
     if not needs_audio_change and not needs_sub_change and not needs_metadata_change:
         return None
@@ -943,10 +1000,12 @@ def build_mkvmerge_command(
         logger,
         needs_audio_change,
         needs_sub_change,
+        needs_metadata_change,
     )
 
     cmd: list[str] = [mkvmerge_path, "-o", str(output_path)]
-    cmd += _assemble_metadata_args(edit_metadata_title, delete_metadata_title, input_path)
+    if needs_metadata_change:
+        cmd += _assemble_metadata_args(edit_metadata_title, delete_metadata_title, input_path)
     cmd += _assemble_track_args(result, needs_audio_change, needs_sub_change)
     cmd += _compute_default_track_flags(tracks, result, needs_audio_change, needs_sub_change, logger, input_path)
     cmd.append(str(input_path))

--- a/src/trimarr/runner.py
+++ b/src/trimarr/runner.py
@@ -16,7 +16,13 @@ from typing import TYPE_CHECKING
 
 from trimarr.database import Database
 from trimarr.hooks import _run_hook
-from trimarr.processor import CorruptOutputError, build_mkvmerge_command, probe_file, process_file
+from trimarr.processor import (
+    CorruptOutputError,
+    build_mkvmerge_command,
+    probe_container_title,
+    probe_file,
+    process_file,
+)
 
 # Width of the separator line used in critical diagnostic messages.
 _LOG_SEPARATOR_WIDTH = 80
@@ -403,6 +409,19 @@ def _process_one_file(
         counts.failed += 1
         return
 
+    # Probe container title when metadata flags are active (issue #72).
+    if cfg.edit_metadata_title or cfg.delete_metadata_title:
+        try:
+            current_title = probe_container_title(cfg.mkvmerge_path, file_path)
+        except RuntimeError as exc:
+            reason = f"probe title failed: {str(exc).splitlines()[0].strip()}"
+            logger.error(f"Could not probe container title for '{file_path}': {exc}")
+            failures.append((file_path, reason))
+            counts.failed += 1
+            return
+    else:
+        current_title = ""
+
     # Build the mkvmerge command (returns None if nothing to do)
     cmd = build_mkvmerge_command(
         mkvmerge_path=cfg.mkvmerge_path,
@@ -419,6 +438,7 @@ def _process_one_file(
         strip_commentary=cfg.strip_commentary,
         strip_subtitle_regex_patterns=cfg.strip_subtitle_regex_patterns,
         keep_undefined_audio=cfg.keep_undefined_audio,
+        current_title=current_title,
     )
 
     if cmd is None:

--- a/tests/unit/test_processor.py
+++ b/tests/unit/test_processor.py
@@ -16,6 +16,7 @@ from trimarr.processor import (
     _atomic_file_replace,
     _spinner,
     build_mkvmerge_command,
+    probe_container_title,
     probe_file,
     process_file,
 )
@@ -70,6 +71,7 @@ def _build_cmd(
     strip_lower_channels: bool = False,
     strip_commentary: bool = False,
     strip_subtitle_regex_patterns: list[re.Pattern] | None = None,
+    current_title: str = "",
 ) -> list[str] | None:
     """Thin wrapper around build_mkvmerge_command with test-friendly defaults."""
     if language is None:
@@ -88,6 +90,7 @@ def _build_cmd(
         strip_lower_channels=strip_lower_channels,
         strip_commentary=strip_commentary,
         strip_subtitle_regex_patterns=strip_subtitle_regex_patterns,
+        current_title=current_title,
     )
 
 
@@ -432,6 +435,91 @@ class TestProbeFile:
 
 
 # ---------------------------------------------------------------------------
+# probe_container_title()
+# ---------------------------------------------------------------------------
+
+
+class TestProbeContainerTitle:
+    """Tests for probe_container_title()."""
+
+    def _mkvmerge_json(self, container_props: dict | None, tracks: list[dict] | None = None) -> str:
+        container = {"properties": container_props or {}} if container_props else {}
+        data: dict = {"container": container}
+        if tracks is not None:
+            data["tracks"] = tracks
+        return json.dumps(data)
+
+    def test_returns_title_when_present(self, tmp_path: Path) -> None:
+        mkv = tmp_path / "movie.mkv"
+        mkv.touch()
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0, stdout=self._mkvmerge_json({"title": "My Movie"}), stderr=""
+            )
+            result = probe_container_title(MKVMERGE, mkv)
+        assert result == "My Movie"
+
+    def test_returns_empty_when_title_absent(self, tmp_path: Path) -> None:
+        mkv = tmp_path / "movie.mkv"
+        mkv.touch()
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout=self._mkvmerge_json({"title": ""}), stderr="")
+            result = probe_container_title(MKVMERGE, mkv)
+        assert result == ""
+
+    def test_returns_empty_when_container_missing(self, tmp_path: Path) -> None:
+        mkv = tmp_path / "movie.mkv"
+        mkv.touch()
+        with patch("subprocess.run") as mock_run:
+            # No "container" key at all
+            mock_run.return_value = MagicMock(returncode=0, stdout=json.dumps({"tracks": []}), stderr="")
+            result = probe_container_title(MKVMERGE, mkv)
+        assert result == ""
+
+    def test_returns_empty_when_title_null(self, tmp_path: Path) -> None:
+        mkv = tmp_path / "movie.mkv"
+        mkv.touch()
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout=self._mkvmerge_json({"title": None}), stderr="")
+            result = probe_container_title(MKVMERGE, mkv)
+        assert result == ""
+
+    def test_raises_on_nonzero_exit(self, tmp_path: Path) -> None:
+        mkv = tmp_path / "bad.mkv"
+        mkv.touch()
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=2, stdout="", stderr="err")
+            with pytest.raises(RuntimeError, match="exit 2"):
+                probe_container_title(MKVMERGE, mkv)
+
+    def test_raises_on_invalid_json(self, tmp_path: Path) -> None:
+        mkv = tmp_path / "bad.mkv"
+        mkv.touch()
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="not json", stderr="")
+            with pytest.raises(RuntimeError, match="parse"):
+                probe_container_title(MKVMERGE, mkv)
+
+    def test_raises_on_timeout(self, tmp_path: Path) -> None:
+        mkv = tmp_path / "movie.mkv"
+        mkv.touch()
+        with (
+            patch("subprocess.run", side_effect=subprocess.TimeoutExpired(cmd=MKVMERGE, timeout=60)),
+            pytest.raises(RuntimeError, match="timed out"),
+        ):
+            probe_container_title(MKVMERGE, mkv)
+
+    def test_raises_on_os_error(self, tmp_path: Path) -> None:
+        mkv = tmp_path / "movie.mkv"
+        mkv.touch()
+        with (
+            patch("subprocess.run", side_effect=OSError("permission denied")),
+            pytest.raises(RuntimeError, match="Could not execute"),
+        ):
+            probe_container_title(MKVMERGE, mkv)
+
+
+# ---------------------------------------------------------------------------
 # build_mkvmerge_command()
 # ---------------------------------------------------------------------------
 
@@ -552,7 +640,7 @@ class TestBuildMkvmergeCommand:
 
     def test_delete_metadata_title_sets_empty_string(self) -> None:
         tracks = _make_tracks(audio_langs=["eng"], sub_langs=[])
-        cmd = _build_cmd(tracks, delete_metadata_title=True)
+        cmd = _build_cmd(tracks, delete_metadata_title=True, current_title="Some Title")
         assert cmd is not None
         assert "--title" in cmd
         idx = cmd.index("--title") + 1
@@ -2276,9 +2364,9 @@ class TestBuildMkvmergeCommandAudioDropNoKeep:
         assert "--subtitle-tracks" not in cmd
 
     def test_needs_metadata_change_true_via_delete_title(self) -> None:
-        """delete_metadata_title=True also sets needs_metadata_change."""
+        """delete_metadata_title=True with a non-empty current title needs a change."""
         tracks = [MkvTrack(id=0, type="video", language=None)]
-        cmd = _build_cmd(tracks, delete_metadata_title=True)
+        cmd = _build_cmd(tracks, delete_metadata_title=True, current_title="Old Movie")
         assert cmd is not None
         assert "--title" in cmd
         idx = cmd.index("--title") + 1
@@ -2288,6 +2376,53 @@ class TestBuildMkvmergeCommandAudioDropNoKeep:
 # ---------------------------------------------------------------------------
 # Branch coverage: _compute_channel_drops_per_group all-unknown channels
 # ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# Metadata title no-op when already matches (issue #72)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildMkvmergeCommandMetadataSkipNoop:
+    """When the container title already matches the requested metadata operation, no remux is needed.
+
+    Issue #72: --delete-metadata-title and --edit-metadata-title must inspect the current
+    container title via the new ``current_title`` parameter and return None when the title
+    is already in the desired state, avoiding a redundant remux after DB loss or config reset.
+    """
+
+    def test_delete_title_when_already_empty_returns_none(self) -> None:
+        """delete_metadata_title with already-empty title → no change needed."""
+        tracks = [MkvTrack(id=0, type="video", language=None)]
+        cmd = _build_cmd(tracks, delete_metadata_title=True, current_title="")
+        assert cmd is None
+
+    def test_delete_title_when_title_present_returns_command(self) -> None:
+        """delete_metadata_title with non-empty title → still needs change."""
+        tracks = [MkvTrack(id=0, type="video", language=None)]
+        inp = Path("/media/Movie.mkv")
+        cmd = _build_cmd(tracks, delete_metadata_title=True, input_path=inp, current_title="Full Title")
+        assert cmd is not None
+        assert "--title" in cmd
+        idx = cmd.index("--title") + 1
+        assert cmd[idx] == ""
+
+    def test_edit_title_when_already_matches_returns_none(self) -> None:
+        """edit_metadata_title when current title already equals stem → no change needed."""
+        inp = Path("/media/My.Movie.mkv")
+        tracks = [MkvTrack(id=0, type="video", language=None)]
+        cmd = _build_cmd(tracks, edit_metadata_title=True, input_path=inp, current_title="My.Movie")
+        assert cmd is None
+
+    def test_edit_title_when_differs_returns_command(self) -> None:
+        """edit_metadata_title when current title differs from stem → still needs change."""
+        inp = Path("/media/My.Movie.mkv")
+        tracks = [MkvTrack(id=0, type="video", language=None)]
+        cmd = _build_cmd(tracks, edit_metadata_title=True, input_path=inp, current_title="Old Title")
+        assert cmd is not None
+        assert "--title" in cmd
+        idx = cmd.index("--title") + 1
+        assert cmd[idx] == "My.Movie"
 
 
 class TestComputeChannelDropsAllUnknown:

--- a/uv.lock
+++ b/uv.lock
@@ -823,7 +823,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/3e/c1/368daee29d1c9b081
 
 [[package]]
 name = "trimarr"
-version = "1.2.10"
+version = "1.2.12"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- `--delete-metadata-title` and `--edit-metadata-title` no longer force a redundant remux when the container title is already in the desired state
- After DB loss or config reset, files with already-correct titles are re-probed but **not** remuxed — fixing the behaviour documented in the README
- Added `probe_container_title()` to extract the title from `mkvmerge -J` output
- 12 new tests covering all no-op and change scenarios

## Changes
- **processor.py**: Extracted `_run_mkvmerge_probe()` shared helper; added `probe_container_title()` function; added `current_title` param to `build_mkvmerge_command()`; guarded `_assemble_metadata_args()` behind `needs_metadata_change`
- **runner.py**: Wire title probing into `_process_one_file()` when metadata flags are active
- **tests**: `TestProbeContainerTitle` (8 tests), `TestBuildMkvmergeCommandMetadataSkipNoop` (4 tests)

## Test Plan
- [x] 632 tests passing, 97.10% coverage
- [x] Ruff, mypy, pre-commit all clean
- [x] Dual-model adversarial review (3 rounds, all clean)