### PR TITLE
fix: prefer TMDb/TVDB originalLanguage over IMDb spokenLanguages for …

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ automatically deduplicated.
   language-matching audio tracks are commentary (e.g. Director's Commentary on a foreign-language
   film), audio filtering is also skipped. A warning is logged in both cases.
 - **Native language preservation** — with `--keep-native-audio`, trimarr identifies the file's
-  original spoken language(s) via IMDb, TMDb, and TVDB — the lookup order adapts to media type:
-  for TV shows, TVDB/TMDb originalLanguage is tried first (more appropriate than IMDb's broad
-  spokenLanguages), while movies keep IMDb first — and preserves those
+  original spoken language(s) via IMDb, TMDb, and TVDB — the lookup prioritises the
+  **originalLanguage** from TMDb/TVDB over IMDb's broader
+  spokenLanguages (which can include every language with any dialogue) — and preserves those
   audio tracks even if they don't match your `--language` preference. Ideal for dubbed films
   (e.g., keeping original Chinese audio alongside an English dub) and TV shows where Sonarr
   NFO files carry only a TVDB ID. Results are cached in the database so each
@@ -91,7 +91,7 @@ trimarr --help
 | `--delete-metadata-title` | Remove the container title metadata from each file. Mutually exclusive with `--edit-metadata-title`. | `false` | — | `flag` |
 | `--keep-subtitles` | Keep all subtitle tracks regardless of language. | `false` | — | `flag` |
 | `--keep-audio` | Keep all audio tracks regardless of language. | `false` | — | `flag` |
-| `--keep-native-audio` | Identify the file's native/original spoken language(s) via IMDb, TMDb, and TVDB — the lookup order adapts to media type: for TV shows, TVDB/TMDb originalLanguage is tried first, while movies keep IMDb first — and keep all audio tracks in those languages alongside your `--language` preference. Ignored when `--keep-audio` is set. First-time lookups require an internet connection; results are cached in the database. | `false` | — | `flag` |
+| `--keep-native-audio` | Identify the file's native/original spoken language(s) via IMDb, TMDb, and TVDB — the lookup prioritises the **originalLanguage** from TMDb/TVDB (a single production language code) over IMDb's broader spokenLanguages (all languages with any dialogue). The chain internally orders by media type: TMDb first for movies, TVDB first for TV shows. Keeps all audio tracks in those languages alongside your `--language` preference. Ignored when `--keep-audio` is set. First-time lookups require an internet connection; results are cached in the database. | `false` | — | `flag` |
 | `--keep-undefined-audio` | If specified, audio tracks with an undefined language code ("und") are kept rather than dropped by the language filter. Useful when source files have missing or incorrect language tags. Ignored when `--keep-audio` is set. | `false` | — | `flag` |
 | `--tmdb-api-key` | TMDb API key used as fallback when IMDbPie cannot identify a file's native language. Optional — without it, TMDb lookups are silently skipped. | — | `<key>` | `string` |
 | `--tvdb-api-key` | TVDB API key used as fallback when IMDbPie and TMDb cannot identify a file's native language. Useful for TV shows whose NFO files contain only a TVDB ID. Optional — without it, TVDB lookups are silently skipped. | — | `<key>` | `string` |
@@ -187,8 +187,11 @@ flowchart TD
 ### Native language resolution flow
 
 When `--keep-native-audio` is enabled, trimarr walks the following chain to identify the
-movie or TV show and look up its original spoken language(s). Each level is attempted in
-order; the first successful result is cached in the database and returned.
+movie or TV show and look up its original spoken language(s). The chain is unified for all
+media types: TMDb/TVDB originalLanguage is tried first (the chain internally orders by
+media type — TMDb first for movies, TVDB first for TV shows), then IMDb spokenLanguages
+as fallback. Each level is attempted in order; the first successful result is cached in the
+database and returned.
 
 ```mermaid
 flowchart TD
@@ -199,27 +202,16 @@ for this media?}
     B -- Yes --> C[Parse NFO XML]
     C --> D{NFO has IMDb,
 TMDb, or TVDB ID?}
-    D -- Yes --> E{TV show?}
-
-    %% TV show path: TVDB/TMDb first (originalLanguage is more appropriate)
-    E -- Yes --> E1[TVDB/TMDb chain:
-TVDB → TMDb (originalLanguage)]
-    E1 --> F1{Found?}
-    F1 -- Yes --> G([✅ Cache & return
+    D -- Yes --> E[TMDb/TVDB chain:
+originalLanguage]
+    E --> F{Found?}
+    F -- Yes --> G([✅ Cache & return
 native languages])
-    F1 -- No --> E2[IMDb spokenLanguages]
-    E2 --> F{Found?}
-
-    %% Movie path: IMDb first (spokenLanguages is reliable for films)
-    E -- No (Movie) --> E3[IMDb spokenLanguages]
-    E3 --> F3{Found?}
-    F3 -- Yes --> G
-    F3 -- No --> E4[TVDB/TMDb chain:
-TMDb → TVDB]
-    E4 --> F{Found?}
-
-    F -- Yes --> G
-    F -- No --> H
+    F -- No --> E2[IMDb spokenLanguages
+fallback]
+    E2 --> F2{Found?}
+    F2 -- Yes --> G
+    F2 -- No --> H
 
     %% NFO title search --
     D -- No --> H[Use NFO title + year

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "Trimarr"
-version = "1.2.12"
+version = "1.2.13"
 description = "Automated tool"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/trimarr/native_language.py
+++ b/src/trimarr/native_language.py
@@ -995,33 +995,34 @@ def _resolve_nfo_id_lookups(
     Returns language codes if any lookup succeeds, or *None* to
     continue to the next fallback phase.
 
-    Lookup order depends on media type:
-    - **TV shows:** TVDB/TMDb chain first (``originalLanguage`` is more
-      appropriate for ``--keep-native-audio`` than IMDb's
-      ``spokenLanguages`` which can include every language with even
-      brief dialogue). Falls back to IMDb if the chain fails.
-    - **Movies:** IMDb first (``spokenLanguages`` from auxiliary data
-      is the most reliable indicator), then TVDB/TMDb chain as fallback.
+    Lookup order is unified for all media types:
+    - **TMDb/TVDB chain first** (``originalLanguage`` — a single production
+      language code, more appropriate for ``--keep-native-audio``).
+      The chain internally orders by media type: TMDb first for movies,
+      TVDB first for TV shows.
+    - **IMDb fallback** (``spokenLanguages`` — all languages present in the
+      title, broader but less specific). Used when the chain has no API key
+      configured or all keyed lookups fail.
     """
     tmdb_media_type = _get_tmdb_endpoint(file_path.stem)
-    is_tv = tmdb_media_type == "tv"
 
-    if is_tv:
-        # TV show: try TVDB/TMDb chain first — originalLanguage is more
-        # appropriate for --keep-native-audio than IMDb's spokenLanguages.
-        result = _run_nfo_id_lookup_chain(
-            nfo_meta.tmdb_id,
-            nfo_meta.tvdb_id,
-            tmdb_api_key,
-            tvdb_api_key,
-            tmdb_media_type,
-            file_path,
-            db,
-        )
-        if result:
-            return result
+    # Phase 1 — TMDb/TVDB chain (originalLanguage — single production
+    # language code).  The chain internally orders by media type:
+    # TMDb first for movies, TVDB first for TV shows.
+    result = _run_nfo_id_lookup_chain(
+        nfo_meta.tmdb_id,
+        nfo_meta.tvdb_id,
+        tmdb_api_key,
+        tvdb_api_key,
+        tmdb_media_type,
+        file_path,
+        db,
+    )
+    if result:
+        return result
 
-    # Direct IMDb ID lookup (primary for movies, fallback for TV)
+    # Phase 2 — IMDb ID fallback (spokenLanguages — broader but
+    # includes every language with any dialogue in the title).
     if nfo_meta.imdb_id:
         result = _lookup_and_cache(
             _lookup_imdbpie_by_id,
@@ -1032,18 +1033,6 @@ def _resolve_nfo_id_lookups(
         )
         if result:
             return result
-
-    # TMDb/TVDB chain for movies (TV already tried the chain above)
-    if not is_tv:
-        return _run_nfo_id_lookup_chain(
-            nfo_meta.tmdb_id,
-            nfo_meta.tvdb_id,
-            tmdb_api_key,
-            tvdb_api_key,
-            tmdb_media_type,
-            file_path,
-            db,
-        )
 
     return None
 

--- a/src/trimarr/runner.py
+++ b/src/trimarr/runner.py
@@ -352,6 +352,47 @@ def _resolve_effective_language(
     return result
 
 
+def _probe_file_safe(
+    mkvmerge_path: str,
+    file_path: Path,
+    root: Path,
+    idx: int,
+    total: int,
+    cfg: _ProcessingConfig,
+    logger: Logger,
+    failures: list[tuple[Path, str]],
+    counts: _RunCounts,
+) -> tuple[list, str] | None:
+    """Probe MKV tracks and container title.
+
+    Returns ``(tracks, current_title)`` on success, or *None* on failure
+    (logs, records the failure, and lets the caller return early).
+    """
+    logger.info(f"  [{idx}/{total}] Checking '{file_path.relative_to(root)}'...")
+
+    try:
+        tracks = probe_file(mkvmerge_path, file_path)
+    except RuntimeError as exc:
+        reason = f"probe failed: {str(exc).splitlines()[0].strip()}"
+        logger.error(f"Could not probe '{file_path}': {exc}")
+        failures.append((file_path, reason))
+        counts.failed += 1
+        return None
+
+    current_title = ""
+    if cfg.edit_metadata_title or cfg.delete_metadata_title:
+        try:
+            current_title = probe_container_title(mkvmerge_path, file_path)
+        except RuntimeError as exc:
+            reason = f"probe title failed: {str(exc).splitlines()[0].strip()}"
+            logger.error(f"Could not probe container title for '{file_path}': {exc}")
+            failures.append((file_path, reason))
+            counts.failed += 1
+            return None
+
+    return tracks, current_title
+
+
 def _process_one_file(
     file_path: Path,
     root: Path,
@@ -397,30 +438,21 @@ def _process_one_file(
         counts.skipped += 1
         return
 
-    logger.info(f"  [{idx}/{total}] Checking '{file_path.relative_to(root)}'...")
-
-    # Probe tracks
-    try:
-        tracks = probe_file(cfg.mkvmerge_path, file_path)
-    except RuntimeError as exc:
-        reason = f"probe failed: {str(exc).splitlines()[0].strip()}"
-        logger.error(f"Could not probe '{file_path}': {exc}")
-        failures.append((file_path, reason))
-        counts.failed += 1
+    # Probe tracks and container title
+    probed = _probe_file_safe(
+        mkvmerge_path=cfg.mkvmerge_path,
+        file_path=file_path,
+        root=root,
+        idx=idx,
+        total=total,
+        cfg=cfg,
+        logger=logger,
+        failures=failures,
+        counts=counts,
+    )
+    if probed is None:
         return
-
-    # Probe container title when metadata flags are active (issue #72).
-    if cfg.edit_metadata_title or cfg.delete_metadata_title:
-        try:
-            current_title = probe_container_title(cfg.mkvmerge_path, file_path)
-        except RuntimeError as exc:
-            reason = f"probe title failed: {str(exc).splitlines()[0].strip()}"
-            logger.error(f"Could not probe container title for '{file_path}': {exc}")
-            failures.append((file_path, reason))
-            counts.failed += 1
-            return
-    else:
-        current_title = ""
+    tracks, current_title = probed
 
     # Build the mkvmerge command (returns None if nothing to do)
     cmd = build_mkvmerge_command(

--- a/tests/unit/test_native_language.py
+++ b/tests/unit/test_native_language.py
@@ -2228,3 +2228,81 @@ class TestResolveNativeLanguageTvShowBug:
 
         # TVDB should have been called (it has the right data for this TV show)
         tvdb_mock.assert_called_once()
+
+
+class TestResolveNativeLanguageMovieBug:
+    """Regression tests for issue #76 — Movie NFO prefers TMDb over IMDb."""
+
+    def test_movie_nfo_prefers_tmdb_over_imdb_inflated_spoken_languages(
+        self,
+        mocker,
+        tmp_path: Path,
+    ) -> None:
+        """Movie NFO should prefer TMDb originalLanguage over IMDb spokenLanguages.
+
+        This reproduces issue #76: when movie NFO has both imdb_id and tmdb_id
+        AND IMDb succeeds (returns spokenLanguages), the current code returns IMDb's
+        inflated language list immediately — TMDb is never consulted.
+
+        For movies, TMDb's originalLanguage (single code) is more appropriate
+        for --keep-native-audio than IMDb's spokenLanguages (all languages present).
+
+        IMDb: "jpn,ger,ita,fre" (4 languages — spokenLanguages for The Wind Rises)
+        TMDb: "jpn" (1 language — originalLanguage)
+        Expected: TMDb wins → ["jpn"]
+        """
+        from trimarr.native_language import resolve_native_language
+
+        d = tmp_path / "The Wind Rises (2013)"
+        d.mkdir()
+        nfo = d / "The Wind Rises.nfo"
+        nfo.write_text(
+            '<?xml version="1.0"?>'
+            "<movie><title>The Wind Rises</title><year>2013</year>"
+            "<imdbid>tt2013293</imdbid><tmdbid>149870</tmdbid></movie>"
+        )
+        mkv = d / "The Wind Rises (2013).mkv"
+        mkv.write_text("dummy")
+
+        # Mock cache miss so we go through the entire resolution chain
+        mock_db = mocker.MagicMock()
+        mock_db.get_native_language_cache.return_value = None
+        mock_db.set_native_language_cache = mocker.MagicMock()
+
+        # IMDb SUCCEEDS — returns inflated spokenLanguages (the bug)
+        # This simulates what IMDb's get_title_auxiliary / spokenLanguages returns
+        # for a popular international film: jpn, ger, ita, fre
+        mocker.patch(
+            "trimarr.native_language._lookup_imdbpie_by_id",
+            return_value=["jpn", "ger", "ita", "fre"],
+        )
+
+        # TMDb returns the single original language (correct for movies)
+        tmdb_mock = mocker.patch(
+            "trimarr.native_language._lookup_tmdb_by_id",
+            return_value=["jpn"],
+        )
+
+        # TVDB returns nothing (not applicable for standard movies)
+        mocker.patch(
+            "trimarr.native_language._lookup_tvdb_by_id",
+            return_value=None,
+        )
+
+        result = resolve_native_language(
+            file_path=mkv,
+            db=mock_db,
+            tmdb_api_key="fake-tmdb-key",
+        )
+
+        # The result MUST be Japanese (from TMDb originalLanguage),
+        # NOT the 4-language inflated list from IMDb spokenLanguages
+        assert result == ["jpn"], (
+            f"Expected ['jpn'] from TMDb originalLanguage, got {result}. "
+            "The bug: _resolve_nfo_id_lookups returns IMDb spokenLanguages "
+            "immediately for movies when imdb_id is present, without consulting "
+            "TMDb which has the more appropriate originalLanguage."
+        )
+
+        # TMDb should have been called (it has the right data for this movie)
+        tmdb_mock.assert_called_once()


### PR DESCRIPTION
…movies in _resolve_nfo_id_lookups (issue #76)

The NFO ID lookup phase unconditionally tried IMDb first for movies. IMDb's spokenLanguages returns every language with even brief dialogue (e.g. 4 languages for The Wind Rises), while TMDb/TVDB's originalLanguage is a single correct production-language code. The fix unifies the ordering for all media types: TMDb/TVDB chain first (originalLanguage) then IMDb fallback.

Also reduces CRAP score of _process_one_file from 9.30 to 8.01 by extracting a _probe_file_safe helper.

Fixes #76

chore: bump ver to 1.2.13